### PR TITLE
Add httpclientmodule imports to all test spec files, add skeletons for additional tests

### DIFF
--- a/src/app/accepted-jammers/accepted-jammers.component.spec.ts
+++ b/src/app/accepted-jammers/accepted-jammers.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { AcceptedJammersComponent } from './accepted-jammers.component';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('AcceptedJammersComponent', () => {
   let component: AcceptedJammersComponent;
@@ -8,7 +8,8 @@ describe('AcceptedJammersComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ AcceptedJammersComponent ]
+      declarations: [ AcceptedJammersComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { HeaderComponent } from './header.component';
 
 describe('HeaderComponent', () => {
@@ -8,7 +8,8 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
+      declarations: [ HeaderComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/jam-requests/jam-requests.component.spec.ts
+++ b/src/app/jam-requests/jam-requests.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { JamRequestsComponent } from './jam-requests.component';
 
 describe('JamRequestsComponent', () => {
@@ -8,7 +8,8 @@ describe('JamRequestsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ JamRequestsComponent ]
+      declarations: [ JamRequestsComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/jammer-profile/jammer-profile.component.spec.ts
+++ b/src/app/jammer-profile/jammer-profile.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { JammerProfileComponent } from './jammer-profile.component';
 
 describe('JammerProfileComponent', () => {
@@ -8,7 +8,8 @@ describe('JammerProfileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ JammerProfileComponent ]
+      declarations: [ JammerProfileComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/results-page/results-page.component.spec.ts
+++ b/src/app/results-page/results-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { ResultsPageComponent } from './results-page.component';
 
 describe('ResultsContainerComponent', () => {
@@ -8,7 +8,8 @@ describe('ResultsContainerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ResultsPageComponent ]
+      declarations: [ ResultsPageComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/searchbar/searchbar.component.spec.ts
+++ b/src/app/searchbar/searchbar.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { SearchbarComponent } from './searchbar.component';
 
 describe('SearchbarComponent', () => {
@@ -8,7 +8,8 @@ describe('SearchbarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SearchbarComponent ]
+      declarations: [ SearchbarComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 
@@ -19,5 +20,10 @@ describe('SearchbarComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render Search for Jammers button', () => {
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('button')).toContain('Search for Jammers');
   });
 });

--- a/src/app/services/user-services.spec.ts
+++ b/src/app/services/user-services.spec.ts
@@ -1,0 +1,22 @@
+import { UserService } from "./user-service";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
+
+describe('UserService', () => {
+    let service: UserService;
+  
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [UserService],
+        imports: [HttpClientModule]
+      });
+  
+      service = TestBed.inject(UserService); // * inject service instance
+    });
+  
+    it('should be created', () => {
+      expect(service).toBeTruthy();
+    });
+  
+
+  });

--- a/src/app/user-edit/user-edit.component.spec.ts
+++ b/src/app/user-edit/user-edit.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { UserEditComponent } from './user-edit.component';
 
 describe('UserEditComponent', () => {
@@ -8,7 +8,8 @@ describe('UserEditComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ UserEditComponent ]
+      declarations: [ UserEditComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/user-info/user-info.component.spec.ts
+++ b/src/app/user-info/user-info.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientModule } from '@angular/common/http';
 import { UserInfoComponent } from './user-info.component';
 
 describe('UserInfoComponent', () => {
@@ -8,7 +8,8 @@ describe('UserInfoComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ UserInfoComponent ]
+      declarations: [ UserInfoComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 

--- a/src/app/user-profile/user-profile.component.spec.ts
+++ b/src/app/user-profile/user-profile.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserInfoComponent } from '../user-info/user-info.component';
 import { UserProfileComponent } from './user-profile.component';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('UserProfileComponent', () => {
   let component: UserProfileComponent;
@@ -8,7 +9,8 @@ describe('UserProfileComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ UserProfileComponent ]
+      declarations: [ UserProfileComponent ],
+      imports: [HttpClientModule]
     })
     .compileComponents();
 


### PR DESCRIPTION
Description
Add httpclientmodule imports to all test spec files, add skeletons for additional tests

Fixes
12/14 tests currently pass as a result of adding these imports (up from 4/14). Most of these tests are fairly simple and I would like to request help coming up with a few others (unit testing in Angular is really, really hard). Please review these tests and suggest any that you think would be good to include.

[x] Bug fix (non-breaking change which fixes an issue)
Checklist:
 [x] My code follows the style guidelines of this project
 [x] I have performed a self-review of my code
 [x] I have made corresponding changes to the documentation (as needed)